### PR TITLE
Add docs for Maybe<T>

### DIFF
--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -9,10 +9,12 @@ To convert a typed value to a ```Maybe``` you can simply call the ```.ToMaybe()`
 ##Checking for a Value
 As a ```Maybe``` has two potential states that should be handled it is possible to match on them using the ```.Match``` method which takes 2 functions, one for handling each state:
 
+```csharp
     var whatWasIt = 
         someMaybeValue.Match(
             Some: theValue => $"It was {theValue}",
             None: () => "It was empty");
+```
 
 In the example above, the variable ```whatWasIt``` is set to a different string value depending on if the ```Maybe``` contained a value or not.
 
@@ -23,6 +25,7 @@ The ```.Match()``` method handles the boilerplate for the situation where _if th
 
 ```.Map()``` handles the situation where you only want to call another method if the ```Maybe``` contains a value, for example, if you want to transform the data. The function passed into a ```.Map()``` should take the type contained in the ```Maybe``` as a parameter, and return a different non-```Maybe``` type. If the ```Maybe``` contains a value ```.Map()``` will call the function with the value inside, and return a new ```Maybe``` of the return type of the function, if it's empty ```.Map()``` will return an empty ```Maybe``` of the return type of the function. The example below takes a ```Maybe<Caterpillar>``` and returns a ```Maybe<Butterfly>```:
 
+```csharp
     private static Butterfly Metamorphosis(Caterpillar c)
     {
         //nature is wonderful
@@ -32,9 +35,11 @@ The ```.Match()``` method handles the boilerplate for the situation where _if th
 
     //this returns a Maybe<Butterfly>
     maybeCaterpillar.Map(Metamorphosis);
+```
 
 ```.Bind()``` is similar to ```.Map()``` but works with a function that also returns a ```Maybe<T>``` and so avoids wrapping the value twice into a ```Maybe<Maybe<T>>```:
 
+```csharp
     private static Maybe<Butterfly> Metamorphosis(Caterpillar c)
     {
         //nature is wonderful
@@ -48,6 +53,7 @@ The ```.Match()``` method handles the boilerplate for the situation where _if th
 
     //this just returns Maybe<Butterfly>
     maybeCaterpillar.Bind(Metamorphosis)
+```
 
 ##Async
 For working with async methods, there are also async versions of these functions: ```.MatchAsync()```, ```.MapAsync()```, and ```.BindAsync()```.

--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -11,11 +11,14 @@ Before using the value in a ```Maybe``` you should first check if it actually co
 
 It's also possible to match on both potential states of a ```Maybe``` using the ```.Match``` method which takes 2 functions, one for handling each state:
 
-    someMaybeValue.Match(
-        Some: theValue => Console.WriteLine($"It was {theValue}"),
-        None: () => Console.WriteLine("It was empty"));
+    var whatWasIt = 
+        someMaybeValue.Match(
+            Some: theValue => $"It was {theValue}",
+            None: () => "It was empty");
 
-The function provided for ```Some``` should take a parameter of the same type as the ```Maybe``` value, the function provided for ```None``` should take no parameters and return the same type as the ```Some``` function. By convention the parameter labels should be included to make the code more readable.
+In the example above, the variable ```whatWasIt``` is set to a different string value depending on if the ```Maybe``` contained a value or not.
+
+The function provided for ```Some``` should take a parameter of the same type as the ```Maybe``` value, the function provided for ```None``` should take no parameters and return the same type as the ```Some``` function. The ```.Match()``` method will then return the value returned by whichever function was invoked. By convention the parameter labels should be included to make the code more readable.
 
 ##Clever Extensions
 The ```.Match()``` method handles the boilerplate for the situation where _if this has a value do one thing, otherwise do something else_. There are other situations that frequently come up when working with a ```Maybe``` that also have handy methods to save on boilerplate, ```.Map()``` and ```.Bind()``` can help to handle these.

--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -4,7 +4,7 @@
 ```Maybe<T>``` is used to represent a value that might not be available. While it is an option to use ```null``` for reference types, it isn't explicit in the type and returning ```null``` can lead to problems when it's not handled properly, using ```Maybe<T>``` instead makes it obvious that the potential lack of a value needs to be handled, and provides some handy methods for dealing with boilerplate based around that.
 
 ##Making a Maybe
-To convert a typed value to a ```Maybe``` you can simply call the ```.ToMaybe()``` extension method, this will even handle if that value is ```null``` by creating an empty ```Maybe``` of that type.
+To convert a typed value to a ```Maybe``` you can simply call the ```.ToMaybe()``` extension method, if the value is ```null``` an empty ```Maybe``` of that type is created.
 
 ##Checking for a Value
 As a ```Maybe``` has two potential states that should be handled it is possible to match on them using the ```.Match``` method which takes 2 functions, one for handling each state:

--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -1,7 +1,7 @@
 ###E247.Fun
 #Maybe&lt;T&gt;
 
-```Maybe<T>``` is used to represent a value that might not be available. While it is an option to use ```null``` for reference types, it isn't explicit in the type system and returning ```null``` can lead to problems when it's not handled properly, using ```Maybe<T>``` instead makes it obvious that the potential lack of a value needs to be handled, and provides some handy methods for dealing with boilerplate based around that.
+```Maybe<T>``` is used to represent a value that might not be available. While it is an option to use ```null``` for reference types, it isn't explicit in the type and returning ```null``` can lead to problems when it's not handled properly, using ```Maybe<T>``` instead makes it obvious that the potential lack of a value needs to be handled, and provides some handy methods for dealing with boilerplate based around that.
 
 ##Making a Maybe
 To convert a typed value to a ```Maybe``` you can simply call the ```.ToMaybe()``` extension method, this will even handle if that value is ```null``` by creating an empty ```Maybe``` of that type.

--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -4,10 +4,10 @@
 ```Maybe<T>``` is used to represent a value that might not be available. While it is an option to use ```null``` for reference types, it isn't explicit in the type and returning ```null``` can lead to problems when it's not handled properly, using ```Maybe<T>``` instead makes it obvious that the potential lack of a value needs to be handled, and provides some handy methods for dealing with boilerplate based around that.
 
 ##Making a Maybe
-To convert a typed value to a ```Maybe``` you can simply call the ```.ToMaybe()``` extension method, if the value is ```null``` an empty ```Maybe``` of that type is created.
+To convert a typed value to a ```Maybe``` you can simply call the ```.ToMaybe()``` extension method, if the value is ```null``` an empty ```Maybe``` of that type is created. To explicitly create an empty ```Maybe``` you can use ```Maybe<T>.Empty()```.
 
 ##Checking for a Value
-As a ```Maybe``` has two potential states that should be handled it is possible to match on them using the ```.Match``` method which takes 2 functions, one for handling each state:
+As a ```Maybe``` has two potential states that should be handled it is possible to match on them using the ```.Match()``` method which takes 2 functions, one for handling each state:
 
 ```csharp
     var whatWasIt = 

--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -7,9 +7,7 @@
 To convert a typed value to a ```Maybe``` you can simply call the ```.ToMaybe()``` extension method, this will even handle if that value is ```null``` by creating an empty ```Maybe``` of that type.
 
 ##Checking for a Value
-Before using the value in a ```Maybe``` you should first check if it actually contains one. This can be done by testing the boolean value of the ```.HasValue``` property or the ```.Any()``` method. 
-
-It's also possible to match on both potential states of a ```Maybe``` using the ```.Match``` method which takes 2 functions, one for handling each state:
+As a ```Maybe``` has two potential states that should be handled it is possible to match on them using the ```.Match``` method which takes 2 functions, one for handling each state:
 
     var whatWasIt = 
         someMaybeValue.Match(

--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -1,0 +1,52 @@
+###E247.Fun
+#Maybe&lt;T&gt;
+
+```Maybe<T>``` is used to represent a value that might not be available. While it is an option to use ```null``` for reference types, it isn't explicit in the type system and returning ```null``` can lead to problems when it's not handled properly, using ```Maybe<T>``` instead makes it obvious that the potential lack of a value needs to be handled, and provides some handy methods for dealing with boilerplate based around that.
+
+##Making a Maybe
+To convert a typed value to a ```Maybe``` you can simply call the ```.ToMaybe()``` extension method, this will even handle if that value is ```null``` by creating an empty ```Maybe``` of that type.
+
+##Checking for a Value
+Before using the value in a ```Maybe``` you should first check if it actually contains one. This can be done by testing the boolean value of the ```.HasValue``` property or the ```.Any()``` method. 
+
+It's also possible to match on both potential states of a ```Maybe``` using the ```.Match``` method which takes 2 functions, one for handling each state:
+
+    someMaybeValue.Match(
+        Some: theValue => Console.WriteLine($"It was {theValue}"),
+        None: () => Console.WriteLine("It was empty"));
+
+The function provided for ```Some``` should take a parameter of the same type as the ```Maybe``` value, the function provided for ```None``` should take no parameters and return the same type as the ```Some``` function. By convention the parameter labels should be included to make the code more readable.
+
+##Clever Extensions
+The ```.Match()``` method handles the boilerplate for the situation where _if this has a value do one thing, otherwise do something else_. There are other situations that frequently come up when working with a ```Maybe``` that also have handy methods to save on boilerplate, ```.Map()``` and ```.Bind()``` can help to handle these.
+
+```.Map()``` handles the situation where you only want to call another method if the ```Maybe``` contains a value, for example, if you want to transform the data. The function passed into a ```.Map()``` should take the type contained in the ```Maybe``` as a parameter, and return a different non-```Maybe``` type. If the ```Maybe``` contains a value ```.Map()``` will call the function with the value inside, and return a new ```Maybe``` of the return type of the function, if it's empty ```.Map()``` will return an empty ```Maybe``` of the return type of the function. The example below takes a ```Maybe<Caterpillar>``` and returns a ```Maybe<Butterfly>```:
+
+    private static Butterfly Metamorphosis(Caterpillar c)
+    {
+        //nature is wonderful
+    }
+
+    ...
+
+    //this returns a Maybe<Butterfly>
+    maybeCaterpillar.Map(Metamorphosis);
+
+```.Bind()``` is similar to ```.Map()``` but works with a function that also returns a ```Maybe<T>``` and so avoids wrapping the value twice into a ```Maybe<Maybe<T>>```:
+
+    private static Maybe<Butterfly> Metamorphosis(Caterpillar c)
+    {
+        //nature is wonderful
+        //but sometimes things go wrong...
+    }
+
+    ...
+
+    //this would return Maybe<Maybe<Butterfly>> which is silly
+    maybeCaterpillar.Map(Metamorphosis)
+
+    //this just returns Maybe<Butterfly>
+    maybeCaterpillar.Bind(Metamorphosis)
+
+##Async
+For working with async methods, there are also async versions of these functions: ```.MatchAsync()```, ```.MapAsync()```, and ```.BindAsync()```.

--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -51,3 +51,6 @@ The ```.Match()``` method handles the boilerplate for the situation where _if th
 
 ##Async
 For working with async methods, there are also async versions of these functions: ```.MatchAsync()```, ```.MapAsync()```, and ```.BindAsync()```.
+
+##Plain Old If
+If you need to check the state of a ```Maybe``` in a way that doesn't quite fit into one of the methods above, typically for something with side effects it's possible to check on the value using a plain old if statement and either the ```.HasValue``` property or ```.Any()``` method, and then extract the value with the ```.Value``` property. But be warned, trying to access the value of an empty ```Maybe``` will throw!


### PR DESCRIPTION
This PR adds some basic documentation for ```Maybe<T>``` using markdown in a docs folder. If we want to use a different format that could be an option, but markdown is easy to write and GitHub supports making it look pretty so I figured it could be a good bet. 

I assigned this to Luciano for correctness checking, but it could also be interesting to get feedback from @nikolajw, @skauge and @Hyrtwol (plus anyone else that I haven't added to the organisation yet for easy tagging) to see if it's useful for explaining the concept and usage.