### PR TITLE
Add TeeBind and TeeBindAsync for Result

### DIFF
--- a/E247.Fun/Result.cs
+++ b/E247.Fun/Result.cs
@@ -1178,5 +1178,24 @@ namespace E247.Fun
                     .Bind<B, Fail, C>(y => select(x, y)));
         }
 
+        public static Result<TSuccess, TFailure> TeeBind<TSuccess, TNewSuccess, TFailure>(
+            this Result<TSuccess, TFailure> @this,
+            Func<TSuccess, Result<TNewSuccess, TFailure>> func) =>
+            @this.Bind(func).Map((TNewSuccess _) => @this.Success);
+
+        public static Task<Result<TSuccess, TFailure>> TeeBind<TSuccess, TNewSuccess, TFailure>(
+            this Task<Result<TSuccess, TFailure>> @this,
+            Func<TSuccess, Result<TNewSuccess, TFailure>> func) =>
+            @this.Bind(func).MapAsync(async (TNewSuccess _) =>(await  @this).Success);
+
+        public static Task<Result<TSuccess, TFailure>> TeeBindAsync<TSuccess, TNewSuccess, TFailure>(
+            this Result<TSuccess, TFailure> @this,
+            Func<TSuccess, Task<Result<TNewSuccess, TFailure>>> func) =>
+            @this.BindAsync(func).Map((TNewSuccess _) => @this.Success);
+
+        public static Task<Result<TSuccess, TFailure>> TeeBindAsync<TSuccess, TNewSuccess, TFailure>(
+            this Task<Result<TSuccess, TFailure>> @this,
+            Func<TSuccess, Task<Result<TNewSuccess, TFailure>>> func) =>
+            @this.BindAsync(func).MapAsync(async (TNewSuccess _) => (await @this).Success);
     }
 }


### PR DESCRIPTION
#10 

TeeBind is used to call a function that returns a Result where we want to
ignore the success value of that result (if it succeeds) but, should it
fail, we want to use the failure value.

This is most useful for side-effecting methods that could fail (e.g.
writing to a database).

This implementation will work for any type of success value in the
function, rather than being limited to just unit - whereas in other Tee
implementations we are limited to returning Unit and must use TeeIgnore to
explicitly disregard a different return type. This is done simply because
TeeIgnoreBind is a bit of a mouthful, and TeeIgnoreBindAsync is rather
much for a simple function.