### PR TITLE
Feature/upgrade to autofixture4

### DIFF
--- a/E247.Fun.UnitTest/ChoiceTests.cs
+++ b/E247.Fun.UnitTest/ChoiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Ploeh.AutoFixture.Xunit2;
+﻿using AutoFixture.Xunit2;
 using Xunit;
 
 namespace E247.Fun.UnitTest

--- a/E247.Fun.UnitTest/E247.Fun.UnitTest.csproj
+++ b/E247.Fun.UnitTest/E247.Fun.UnitTest.csproj
@@ -4,7 +4,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofixture.Xunit2" Version="3.50.6" />
+    <PackageReference Include="Autofixture.Xunit2" Version="4.0.0-rc1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170425-07" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/E247.Fun.UnitTest/EnumerableTests.cs
+++ b/E247.Fun.UnitTest/EnumerableTests.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Ploeh.AutoFixture.Xunit2;
+using AutoFixture.Xunit2;
 using Xunit;
 
 namespace E247.Fun.UnitTest

--- a/E247.Fun.UnitTest/FunTests.cs
+++ b/E247.Fun.UnitTest/FunTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
-using Ploeh.AutoFixture.Xunit2;
+using AutoFixture.Xunit2;
 using Xunit;
 using static E247.Fun.Fun;
 

--- a/E247.Fun.UnitTest/MaybeTests.cs
+++ b/E247.Fun.UnitTest/MaybeTests.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using E247.Fun;
 using E247.Fun.Exceptions;
-using Ploeh.AutoFixture.Xunit2;
+using AutoFixture.Xunit2;
 using Xunit;
 using Xunit.Extensions;
 using static E247.Fun.Fun;

--- a/E247.Fun.UnitTest/ResultTests.cs
+++ b/E247.Fun.UnitTest/ResultTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using E247.Fun.Exceptions;
-using Ploeh.AutoFixture.Xunit2;
+using AutoFixture.Xunit2;
 using Xunit;
 using static E247.Fun.Unit;
 using static E247.Fun.Fun;

--- a/E247.Fun.UnitTest/TuplesTests.cs
+++ b/E247.Fun.UnitTest/TuplesTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using Ploeh.AutoFixture.Xunit2;
+using AutoFixture.Xunit2;
 using Xunit;
 using static E247.Fun.Tuples;
 using static E247.Fun.Fun;


### PR DESCRIPTION
Updates the autofixture4 to get rid of the target warnings when restoring AutoFixture 3.50.6. See
See https://github.com/AutoFixture/AutoFixture/wiki/v4.0-Release-Notes